### PR TITLE
Aggragate the calculation of populations' destination during each simulating iteration.

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -12,7 +12,7 @@ healthcare_infection_correction
 from motion import update_positions, out_of_bounds, update_randoms,\
 get_motion_parameters
 from path_planning import go_to_location, set_destination, check_at_destination,\
-keep_at_destination, reset_destinations
+keep_at_destination, reset_destinations, update_pops_destination
 from population import initialize_population, initialize_destination_matrix,\
 set_destination_bounds, save_data, save_population, Population_trackers
 from visualiser import build_fig, draw_tstep, set_style, plot_sir

--- a/simulation.py
+++ b/simulation.py
@@ -64,28 +64,8 @@ class Simulation():
             #initialize figure
             self.fig, self.spec, self.ax1, self.ax2 = build_fig(self.Config)
 
-        #check destinations if active
-        #define motion vectors if destinations active and not everybody is at destination
-        active_dests = len(self.population[self.population[:,11] != 0]) # look op this only once
-
-        if active_dests > 0 and len(self.population[self.population[:,12] == 0]) > 0:
-            self.population = set_destination(self.population, self.destinations)
-            self.population = check_at_destination(self.population, self.destinations,
-                                                   wander_factor = self.Config.wander_factor_dest,
-                                                   speed = self.Config.speed)
-
-        if active_dests > 0 and len(self.population[self.population[:,12] == 1]) > 0:
-            #keep them at destination
-            self.population = keep_at_destination(self.population, self.destinations,
-                                                  self.Config.wander_factor)
-
-        #out of bounds
-        #define bounds arrays, excluding those who are marked as having a custom destination
-        if len(self.population[:,11] == 0) > 0:
-            _xbounds = np.array([[self.Config.xbounds[0] + 0.02, self.Config.xbounds[1] - 0.02]] * len(self.population[self.population[:,11] == 0]))
-            _ybounds = np.array([[self.Config.ybounds[0] + 0.02, self.Config.ybounds[1] - 0.02]] * len(self.population[self.population[:,11] == 0]))
-            self.population[self.population[:,11] == 0] = out_of_bounds(self.population[self.population[:,11] == 0],
-                                                                        _xbounds, _ybounds)
+        #update populations' destination conditioning on their current status and the information of destinations.                                                          _xbounds, _ybounds)
+        self.population = update_pops_destination(self.population, self.destinations, self.Config)
 
         #set randoms
         if self.Config.lockdown:


### PR DESCRIPTION
The original code puts the classification of people with different moving status(like whether arrive at a destination, or whether have a destination) in the iteration function. However, the invariant is all people should be checked and updated on their next moving direction. In other words, functions set_destination, check_at_destination and keep_at_destination should be executed every iteration.

In addition, all of the three functions are related to the motions of populations.

Thus, the class simulation should access the updating process of moving strategy through an aggregated root, and avoid deciding which update strategies to implement, or executing the function to update the destination one by one. Instead, it just needs to call an aggregated function, and then, the function will update all destinations with corresponding strategies implicitly.

To achieve this, I replace the set_destination, check_at_destination and keep_at_destination with an new root function named update_pops_destination.

Also, some new variables are introduced in the new designed function to avoid repeated calculation. 